### PR TITLE
Helps to identify the icon 

### DIFF
--- a/client/src/components/spoolIcon.css
+++ b/client/src/components/spoolIcon.css
@@ -18,6 +18,7 @@
 .spool-icon * {
   flex: 1 1 0px;
   border-radius: 2px;
+  border: #44444430 solid 2px;
 }
 
 .spool-icon.vertical *:first-child {


### PR DESCRIPTION
When there is low contrast between color and table background
Before:
<img width="217" alt="before" src="https://github.com/user-attachments/assets/11ffb799-4d1e-43ab-ae42-a5e8796bee07">

After:
<img width="246" alt="after" src="https://github.com/user-attachments/assets/4031cdd9-dd59-4691-8ba3-3f547d21ea0a">

After on dark background:
<img width="225" alt="after_on_dark" src="https://github.com/user-attachments/assets/42ae01d4-da4d-47cc-a051-ca9f738e0605">
